### PR TITLE
Upgrade to hdf5 1.8.18

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 1
+  number: 2
   skip: true  # [win]
   detect_binary_files_with_prefix: true
 
@@ -23,13 +23,13 @@ requirements:
     - cmake
     - pkg-config
     - gcc
-    - hdf5 1.8.17|1.8.17.*
+    - hdf5 1.8.18|1.8.18.*
     - git
     - mpich
   run:
     - mpich
     - libgfortran
-    - hdf5 1.8.17|1.8.17.*
+    - hdf5 1.8.18|1.8.18.*
 
 test:
   commands:


### PR DESCRIPTION
A few CVEs were reported and fixed in hdf5 back in November 2016: http://blog.talosintelligence.com/2016/11/hdf5-vulns.html

The hdf5 release notes for that release are available here: https://support.hdfgroup.org/ftp/HDF5/current18/src/hdf5-1.8.18-RELEASE.txt

For additional info, please see: https://github.com/conda-forge/hdf5-feedstock/pull/68 and https://github.com/conda-forge/hdf5-feedstock/issues/71