### PR TITLE
Make sure Python API gets installed

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -2,6 +2,7 @@
 set -x
 set -e
 
+# Build and install executable
 mkdir -p build
 cd build
 cmake -DCMAKE_INSTALL_PREFIX="${PREFIX}" \
@@ -10,3 +11,7 @@ cmake -DCMAKE_INSTALL_PREFIX="${PREFIX}" \
   ..
 make -j "${CPU_COUNT}"
 make install
+cd ..
+
+# Install Python API
+$PYTHON -m pip install . --no-deps -vv

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,6 +16,7 @@ build:
   number: 1
   skip: true  # [win]
   skip: true  # [osx]
+  skip: true  # [py<35]
   detect_binary_files_with_prefix: true
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set org = "mit-crpg" %}
+{% set org = "openmc-dev" %}
 {% set name = "openmc" %}
 {% set version = "0.11.0" %}
 {% set sha256 = "5127dd50dc02212a310a384a169214e6320812b906f5e135299b9202180d9414" %}
@@ -13,7 +13,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 0
+  number: 1
   skip: true  # [win]
   skip: true  # [osx]
   detect_binary_files_with_prefix: true
@@ -22,13 +22,13 @@ requirements:
   build:
     - cmake
     - pkg-config
-    - {{ compiler('fortran') }}
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
   host:
     - hdf5
     - git
     - setuptools
+    - pip
     - numpy
     - cython
     - matplotlib
@@ -37,7 +37,6 @@ requirements:
   run:
     - hdf5
     - python
-    - six
     - {{ pin_compatible('numpy') }}
     - h5py
     - scipy
@@ -50,20 +49,27 @@ test:
   commands:
     - test -f "${PREFIX}/bin/openmc"
     - openmc --version
+  imports:
+    - openmc
+    - openmc.data
+    - openmc.lib
 
 about:
-  home: http://openmc.readthedocs.io
+  home: https://openmc.org
   license: MIT
   license_file: LICENSE
   summary: 'OpenMC Monte Carlo Code'
   description: |
-    OpenMC is a Monte Carlo particle transport simulation code focused on
-    neutron criticality calculations. It is capable of simulating 3D models
-    based on constructive solid geometry with second-order surfaces. The
-    particle interaction data is based on ACE format cross sections, also
-    used in the MCNP and Serpent Monte Carlo codes.
-  doc_url: http://openmc.readthedocs.io
-  dev_url: https://github.com/mit-crpg/openmc
+    OpenMC is a community-developed Monte Carlo neutron and photon transport
+    simulation code. It is capable of performing fixed source, k-eigenvalue, and
+    subcritical multiplication calculations on models built using either a
+    constructive solid geometry or CAD representation. OpenMC supports both
+    continuous-energy and multigroup transport. The continuous-energy particle
+    interaction data is based on a native HDF5 format that can be generated from
+    ACE files produced by NJOY. Parallelism is enabled via a hybrid MPI and
+    OpenMP programming model.
+  doc_url: https://docs.openmc.org
+  dev_url: https://github.com/openmc-dev/openmc
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
Currently the recipe for OpenMC installs the `openmc` executable but not the corresponding Python API. I've tried to fix that here and added some import tests to make sure things work appropriately. Some of the meta information was also out of date, so I've updated that as well (including removing the dependency on a Fortran compiler).