### PR TITLE
Install cmake config files in lib, not lib64

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -8,16 +8,16 @@ jobs:
     vmImage: ubuntu-latest
   strategy:
     matrix:
-      linux_64_numpy1.17python3.6.____cpython:
-        CONFIG: linux_64_numpy1.17python3.6.____cpython
+      linux_64_numpy1.18python3.6.____cpython:
+        CONFIG: linux_64_numpy1.18python3.6.____cpython
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-comp7
-      linux_64_numpy1.17python3.7.____cpython:
-        CONFIG: linux_64_numpy1.17python3.7.____cpython
+      linux_64_numpy1.18python3.7.____cpython:
+        CONFIG: linux_64_numpy1.18python3.7.____cpython
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-comp7
-      linux_64_numpy1.17python3.8.____cpython:
-        CONFIG: linux_64_numpy1.17python3.8.____cpython
+      linux_64_numpy1.18python3.8.____cpython:
+        CONFIG: linux_64_numpy1.18python3.8.____cpython
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-comp7
       linux_64_numpy1.19python3.9.____cpython:

--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -8,14 +8,14 @@ jobs:
     vmImage: macOS-10.15
   strategy:
     matrix:
-      osx_64_numpy1.17python3.6.____cpython:
-        CONFIG: osx_64_numpy1.17python3.6.____cpython
+      osx_64_numpy1.18python3.6.____cpython:
+        CONFIG: osx_64_numpy1.18python3.6.____cpython
         UPLOAD_PACKAGES: 'True'
-      osx_64_numpy1.17python3.7.____cpython:
-        CONFIG: osx_64_numpy1.17python3.7.____cpython
+      osx_64_numpy1.18python3.7.____cpython:
+        CONFIG: osx_64_numpy1.18python3.7.____cpython
         UPLOAD_PACKAGES: 'True'
-      osx_64_numpy1.17python3.8.____cpython:
-        CONFIG: osx_64_numpy1.17python3.8.____cpython
+      osx_64_numpy1.18python3.8.____cpython:
+        CONFIG: osx_64_numpy1.18python3.8.____cpython
         UPLOAD_PACKAGES: 'True'
       osx_64_numpy1.19python3.9.____cpython:
         CONFIG: osx_64_numpy1.19python3.9.____cpython

--- a/.ci_support/linux_64_numpy1.18python3.6.____cpython.yaml
+++ b/.ci_support/linux_64_numpy1.18python3.6.____cpython.yaml
@@ -17,7 +17,7 @@ docker_image:
 hdf5:
 - 1.10.6
 numpy:
-- '1.17'
+- '1.18'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_64_numpy1.18python3.7.____cpython.yaml
+++ b/.ci_support/linux_64_numpy1.18python3.7.____cpython.yaml
@@ -1,33 +1,35 @@
-MACOSX_DEPLOYMENT_TARGET:
-- '10.9'
 c_compiler:
-- clang
+- gcc
 c_compiler_version:
-- '11'
+- '9'
+cdt_name:
+- cos6
 channel_sources:
 - conda-forge,defaults
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- clangxx
+- gxx
 cxx_compiler_version:
-- '11'
+- '9'
+docker_image:
+- quay.io/condaforge/linux-anvil-comp7
 hdf5:
 - 1.10.6
-macos_machine:
-- x86_64-apple-darwin13.4.0
 numpy:
-- '1.17'
+- '1.18'
 pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.6.* *_cpython
+- 3.7.* *_cpython
 target_platform:
-- osx-64
+- linux-64
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
+- - cdt_name
+  - docker_image
 - - python
   - numpy

--- a/.ci_support/linux_64_numpy1.18python3.8.____cpython.yaml
+++ b/.ci_support/linux_64_numpy1.18python3.8.____cpython.yaml
@@ -17,7 +17,7 @@ docker_image:
 hdf5:
 - 1.10.6
 numpy:
-- '1.17'
+- '1.18'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/osx_64_numpy1.18python3.6.____cpython.yaml
+++ b/.ci_support/osx_64_numpy1.18python3.6.____cpython.yaml
@@ -1,35 +1,33 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.9'
 c_compiler:
-- gcc
+- clang
 c_compiler_version:
-- '9'
-cdt_name:
-- cos6
+- '11'
 channel_sources:
 - conda-forge,defaults
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- gxx
+- clangxx
 cxx_compiler_version:
-- '9'
-docker_image:
-- quay.io/condaforge/linux-anvil-comp7
+- '11'
 hdf5:
 - 1.10.6
+macos_machine:
+- x86_64-apple-darwin13.4.0
 numpy:
-- '1.17'
+- '1.18'
 pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.7.* *_cpython
+- 3.6.* *_cpython
 target_platform:
-- linux-64
+- osx-64
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
-- - cdt_name
-  - docker_image
 - - python
   - numpy

--- a/.ci_support/osx_64_numpy1.18python3.7.____cpython.yaml
+++ b/.ci_support/osx_64_numpy1.18python3.7.____cpython.yaml
@@ -17,13 +17,13 @@ hdf5:
 macos_machine:
 - x86_64-apple-darwin13.4.0
 numpy:
-- '1.17'
+- '1.18'
 pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.8.* *_cpython
+- 3.7.* *_cpython
 target_platform:
 - osx-64
 zip_keys:

--- a/.ci_support/osx_64_numpy1.18python3.8.____cpython.yaml
+++ b/.ci_support/osx_64_numpy1.18python3.8.____cpython.yaml
@@ -17,13 +17,13 @@ hdf5:
 macos_machine:
 - x86_64-apple-darwin13.4.0
 numpy:
-- '1.17'
+- '1.18'
 pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.7.* *_cpython
+- 3.8.* *_cpython
 target_platform:
 - osx-64
 zip_keys:

--- a/README.md
+++ b/README.md
@@ -41,24 +41,24 @@ Current build status
         <table>
           <thead><tr><th>Variant</th><th>Status</th></tr></thead>
           <tbody><tr>
-              <td>linux_64_numpy1.17python3.6.____cpython</td>
+              <td>linux_64_numpy1.18python3.6.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=5658&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/openmc-feedstock?branchName=master&jobName=linux&configuration=linux_64_numpy1.17python3.6.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/openmc-feedstock?branchName=master&jobName=linux&configuration=linux_64_numpy1.18python3.6.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_64_numpy1.17python3.7.____cpython</td>
+              <td>linux_64_numpy1.18python3.7.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=5658&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/openmc-feedstock?branchName=master&jobName=linux&configuration=linux_64_numpy1.17python3.7.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/openmc-feedstock?branchName=master&jobName=linux&configuration=linux_64_numpy1.18python3.7.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_64_numpy1.17python3.8.____cpython</td>
+              <td>linux_64_numpy1.18python3.8.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=5658&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/openmc-feedstock?branchName=master&jobName=linux&configuration=linux_64_numpy1.17python3.8.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/openmc-feedstock?branchName=master&jobName=linux&configuration=linux_64_numpy1.18python3.8.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
@@ -69,24 +69,24 @@ Current build status
                 </a>
               </td>
             </tr><tr>
-              <td>osx_64_numpy1.17python3.6.____cpython</td>
+              <td>osx_64_numpy1.18python3.6.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=5658&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/openmc-feedstock?branchName=master&jobName=osx&configuration=osx_64_numpy1.17python3.6.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/openmc-feedstock?branchName=master&jobName=osx&configuration=osx_64_numpy1.18python3.6.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx_64_numpy1.17python3.7.____cpython</td>
+              <td>osx_64_numpy1.18python3.7.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=5658&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/openmc-feedstock?branchName=master&jobName=osx&configuration=osx_64_numpy1.17python3.7.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/openmc-feedstock?branchName=master&jobName=osx&configuration=osx_64_numpy1.18python3.7.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx_64_numpy1.17python3.8.____cpython</td>
+              <td>osx_64_numpy1.18python3.8.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=5658&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/openmc-feedstock?branchName=master&jobName=osx&configuration=osx_64_numpy1.17python3.8.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/openmc-feedstock?branchName=master&jobName=osx&configuration=osx_64_numpy1.18python3.8.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -6,9 +6,10 @@ set -e
 mkdir -p build
 cd build
 cmake -DCMAKE_INSTALL_PREFIX="${PREFIX}" \
-  -DCMAKE_BUILD_TYPE=Release \
-  -DHDF5_ROOT="${PREFIX}" \
-  ..
+      -DCMAKE_INSTALL_LIBDIR=lib \
+      -DCMAKE_BUILD_TYPE=Release \
+      -DHDF5_ROOT="${PREFIX}" \
+      ..
 make -j "${CPU_COUNT}"
 make install
 cd ..

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,7 +28,7 @@ source:
     folder: vendor/fmt
 
 build:
-  number: 0
+  number: 1
   skip: true  # [win]
   skip: true  # [py<35]
   detect_binary_files_with_prefix: true


### PR DESCRIPTION
Trying to use `find_package(OpenMC HINTS $ENV{CONDA_PREFIX})` in CMake doesn't work with the conda-forge package right now because it doesn't search `lib64` by default. This PR changes where OpenMCConfig.cmake is installed to (lib instead of lib64) so that `find_package` should work appropriately.