### PR TITLE
Fix pip check and add missing ipython dependency

### DIFF
--- a/.ci_support/osx_64_dagmcdagmcmpimpichnumpy1.19python3.7.____cpython.yaml
+++ b/.ci_support/osx_64_dagmcdagmcmpimpichnumpy1.19python3.7.____cpython.yaml
@@ -3,7 +3,7 @@ MACOSX_DEPLOYMENT_TARGET:
 c_compiler:
 - clang
 c_compiler_version:
-- '12'
+- '13'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -11,7 +11,7 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '12'
+- '13'
 dagmc:
 - dagmc
 hdf5:

--- a/.ci_support/osx_64_dagmcdagmcmpimpichnumpy1.19python3.8.____cpython.yaml
+++ b/.ci_support/osx_64_dagmcdagmcmpimpichnumpy1.19python3.8.____cpython.yaml
@@ -3,7 +3,7 @@ MACOSX_DEPLOYMENT_TARGET:
 c_compiler:
 - clang
 c_compiler_version:
-- '12'
+- '13'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -11,7 +11,7 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '12'
+- '13'
 dagmc:
 - dagmc
 hdf5:

--- a/.ci_support/osx_64_dagmcdagmcmpimpichnumpy1.19python3.9.____cpython.yaml
+++ b/.ci_support/osx_64_dagmcdagmcmpimpichnumpy1.19python3.9.____cpython.yaml
@@ -3,7 +3,7 @@ MACOSX_DEPLOYMENT_TARGET:
 c_compiler:
 - clang
 c_compiler_version:
-- '12'
+- '13'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -11,7 +11,7 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '12'
+- '13'
 dagmc:
 - dagmc
 hdf5:

--- a/.ci_support/osx_64_dagmcdagmcmpimpichnumpy1.21python3.10.____cpython.yaml
+++ b/.ci_support/osx_64_dagmcdagmcmpimpichnumpy1.21python3.10.____cpython.yaml
@@ -3,7 +3,7 @@ MACOSX_DEPLOYMENT_TARGET:
 c_compiler:
 - clang
 c_compiler_version:
-- '12'
+- '13'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -11,7 +11,7 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '12'
+- '13'
 dagmc:
 - dagmc
 hdf5:

--- a/.ci_support/osx_64_dagmcdagmcmpinompinumpy1.19python3.7.____cpython.yaml
+++ b/.ci_support/osx_64_dagmcdagmcmpinompinumpy1.19python3.7.____cpython.yaml
@@ -3,7 +3,7 @@ MACOSX_DEPLOYMENT_TARGET:
 c_compiler:
 - clang
 c_compiler_version:
-- '12'
+- '13'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -11,7 +11,7 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '12'
+- '13'
 dagmc:
 - dagmc
 hdf5:

--- a/.ci_support/osx_64_dagmcdagmcmpinompinumpy1.19python3.8.____cpython.yaml
+++ b/.ci_support/osx_64_dagmcdagmcmpinompinumpy1.19python3.8.____cpython.yaml
@@ -3,7 +3,7 @@ MACOSX_DEPLOYMENT_TARGET:
 c_compiler:
 - clang
 c_compiler_version:
-- '12'
+- '13'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -11,7 +11,7 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '12'
+- '13'
 dagmc:
 - dagmc
 hdf5:

--- a/.ci_support/osx_64_dagmcdagmcmpinompinumpy1.19python3.9.____cpython.yaml
+++ b/.ci_support/osx_64_dagmcdagmcmpinompinumpy1.19python3.9.____cpython.yaml
@@ -3,7 +3,7 @@ MACOSX_DEPLOYMENT_TARGET:
 c_compiler:
 - clang
 c_compiler_version:
-- '12'
+- '13'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -11,7 +11,7 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '12'
+- '13'
 dagmc:
 - dagmc
 hdf5:

--- a/.ci_support/osx_64_dagmcdagmcmpinompinumpy1.21python3.10.____cpython.yaml
+++ b/.ci_support/osx_64_dagmcdagmcmpinompinumpy1.21python3.10.____cpython.yaml
@@ -3,7 +3,7 @@ MACOSX_DEPLOYMENT_TARGET:
 c_compiler:
 - clang
 c_compiler_version:
-- '12'
+- '13'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -11,7 +11,7 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '12'
+- '13'
 dagmc:
 - dagmc
 hdf5:

--- a/.ci_support/osx_64_dagmcdagmcmpiopenmpinumpy1.19python3.7.____cpython.yaml
+++ b/.ci_support/osx_64_dagmcdagmcmpiopenmpinumpy1.19python3.7.____cpython.yaml
@@ -3,7 +3,7 @@ MACOSX_DEPLOYMENT_TARGET:
 c_compiler:
 - clang
 c_compiler_version:
-- '12'
+- '13'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -11,7 +11,7 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '12'
+- '13'
 dagmc:
 - dagmc
 hdf5:

--- a/.ci_support/osx_64_dagmcdagmcmpiopenmpinumpy1.19python3.8.____cpython.yaml
+++ b/.ci_support/osx_64_dagmcdagmcmpiopenmpinumpy1.19python3.8.____cpython.yaml
@@ -3,7 +3,7 @@ MACOSX_DEPLOYMENT_TARGET:
 c_compiler:
 - clang
 c_compiler_version:
-- '12'
+- '13'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -11,7 +11,7 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '12'
+- '13'
 dagmc:
 - dagmc
 hdf5:

--- a/.ci_support/osx_64_dagmcdagmcmpiopenmpinumpy1.19python3.9.____cpython.yaml
+++ b/.ci_support/osx_64_dagmcdagmcmpiopenmpinumpy1.19python3.9.____cpython.yaml
@@ -3,7 +3,7 @@ MACOSX_DEPLOYMENT_TARGET:
 c_compiler:
 - clang
 c_compiler_version:
-- '12'
+- '13'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -11,7 +11,7 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '12'
+- '13'
 dagmc:
 - dagmc
 hdf5:

--- a/.ci_support/osx_64_dagmcdagmcmpiopenmpinumpy1.21python3.10.____cpython.yaml
+++ b/.ci_support/osx_64_dagmcdagmcmpiopenmpinumpy1.21python3.10.____cpython.yaml
@@ -3,7 +3,7 @@ MACOSX_DEPLOYMENT_TARGET:
 c_compiler:
 - clang
 c_compiler_version:
-- '12'
+- '13'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -11,7 +11,7 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '12'
+- '13'
 dagmc:
 - dagmc
 hdf5:

--- a/.ci_support/osx_64_dagmcnodagmcmpimpichnumpy1.19python3.7.____cpython.yaml
+++ b/.ci_support/osx_64_dagmcnodagmcmpimpichnumpy1.19python3.7.____cpython.yaml
@@ -3,7 +3,7 @@ MACOSX_DEPLOYMENT_TARGET:
 c_compiler:
 - clang
 c_compiler_version:
-- '12'
+- '13'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -11,7 +11,7 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '12'
+- '13'
 dagmc:
 - nodagmc
 hdf5:

--- a/.ci_support/osx_64_dagmcnodagmcmpimpichnumpy1.19python3.8.____cpython.yaml
+++ b/.ci_support/osx_64_dagmcnodagmcmpimpichnumpy1.19python3.8.____cpython.yaml
@@ -3,7 +3,7 @@ MACOSX_DEPLOYMENT_TARGET:
 c_compiler:
 - clang
 c_compiler_version:
-- '12'
+- '13'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -11,7 +11,7 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '12'
+- '13'
 dagmc:
 - nodagmc
 hdf5:

--- a/.ci_support/osx_64_dagmcnodagmcmpimpichnumpy1.19python3.9.____cpython.yaml
+++ b/.ci_support/osx_64_dagmcnodagmcmpimpichnumpy1.19python3.9.____cpython.yaml
@@ -3,7 +3,7 @@ MACOSX_DEPLOYMENT_TARGET:
 c_compiler:
 - clang
 c_compiler_version:
-- '12'
+- '13'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -11,7 +11,7 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '12'
+- '13'
 dagmc:
 - nodagmc
 hdf5:

--- a/.ci_support/osx_64_dagmcnodagmcmpimpichnumpy1.21python3.10.____cpython.yaml
+++ b/.ci_support/osx_64_dagmcnodagmcmpimpichnumpy1.21python3.10.____cpython.yaml
@@ -3,7 +3,7 @@ MACOSX_DEPLOYMENT_TARGET:
 c_compiler:
 - clang
 c_compiler_version:
-- '12'
+- '13'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -11,7 +11,7 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '12'
+- '13'
 dagmc:
 - nodagmc
 hdf5:

--- a/.ci_support/osx_64_dagmcnodagmcmpinompinumpy1.19python3.7.____cpython.yaml
+++ b/.ci_support/osx_64_dagmcnodagmcmpinompinumpy1.19python3.7.____cpython.yaml
@@ -3,7 +3,7 @@ MACOSX_DEPLOYMENT_TARGET:
 c_compiler:
 - clang
 c_compiler_version:
-- '12'
+- '13'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -11,7 +11,7 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '12'
+- '13'
 dagmc:
 - nodagmc
 hdf5:

--- a/.ci_support/osx_64_dagmcnodagmcmpinompinumpy1.19python3.8.____cpython.yaml
+++ b/.ci_support/osx_64_dagmcnodagmcmpinompinumpy1.19python3.8.____cpython.yaml
@@ -3,7 +3,7 @@ MACOSX_DEPLOYMENT_TARGET:
 c_compiler:
 - clang
 c_compiler_version:
-- '12'
+- '13'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -11,7 +11,7 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '12'
+- '13'
 dagmc:
 - nodagmc
 hdf5:

--- a/.ci_support/osx_64_dagmcnodagmcmpinompinumpy1.19python3.9.____cpython.yaml
+++ b/.ci_support/osx_64_dagmcnodagmcmpinompinumpy1.19python3.9.____cpython.yaml
@@ -3,7 +3,7 @@ MACOSX_DEPLOYMENT_TARGET:
 c_compiler:
 - clang
 c_compiler_version:
-- '12'
+- '13'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -11,7 +11,7 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '12'
+- '13'
 dagmc:
 - nodagmc
 hdf5:

--- a/.ci_support/osx_64_dagmcnodagmcmpinompinumpy1.21python3.10.____cpython.yaml
+++ b/.ci_support/osx_64_dagmcnodagmcmpinompinumpy1.21python3.10.____cpython.yaml
@@ -3,7 +3,7 @@ MACOSX_DEPLOYMENT_TARGET:
 c_compiler:
 - clang
 c_compiler_version:
-- '12'
+- '13'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -11,7 +11,7 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '12'
+- '13'
 dagmc:
 - nodagmc
 hdf5:

--- a/.ci_support/osx_64_dagmcnodagmcmpiopenmpinumpy1.19python3.7.____cpython.yaml
+++ b/.ci_support/osx_64_dagmcnodagmcmpiopenmpinumpy1.19python3.7.____cpython.yaml
@@ -3,7 +3,7 @@ MACOSX_DEPLOYMENT_TARGET:
 c_compiler:
 - clang
 c_compiler_version:
-- '12'
+- '13'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -11,7 +11,7 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '12'
+- '13'
 dagmc:
 - nodagmc
 hdf5:

--- a/.ci_support/osx_64_dagmcnodagmcmpiopenmpinumpy1.19python3.8.____cpython.yaml
+++ b/.ci_support/osx_64_dagmcnodagmcmpiopenmpinumpy1.19python3.8.____cpython.yaml
@@ -3,7 +3,7 @@ MACOSX_DEPLOYMENT_TARGET:
 c_compiler:
 - clang
 c_compiler_version:
-- '12'
+- '13'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -11,7 +11,7 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '12'
+- '13'
 dagmc:
 - nodagmc
 hdf5:

--- a/.ci_support/osx_64_dagmcnodagmcmpiopenmpinumpy1.19python3.9.____cpython.yaml
+++ b/.ci_support/osx_64_dagmcnodagmcmpiopenmpinumpy1.19python3.9.____cpython.yaml
@@ -3,7 +3,7 @@ MACOSX_DEPLOYMENT_TARGET:
 c_compiler:
 - clang
 c_compiler_version:
-- '12'
+- '13'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -11,7 +11,7 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '12'
+- '13'
 dagmc:
 - nodagmc
 hdf5:

--- a/.ci_support/osx_64_dagmcnodagmcmpiopenmpinumpy1.21python3.10.____cpython.yaml
+++ b/.ci_support/osx_64_dagmcnodagmcmpiopenmpinumpy1.21python3.10.____cpython.yaml
@@ -3,7 +3,7 @@ MACOSX_DEPLOYMENT_TARGET:
 c_compiler:
 - clang
 c_compiler_version:
-- '12'
+- '13'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -11,7 +11,7 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '12'
+- '13'
 dagmc:
 - nodagmc
 hdf5:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,8 @@ version: 2
 jobs:
   build:
     working_directory: ~/test
-    machine: true
+    machine:
+      image: ubuntu-2004:current
     steps:
       - run:
           # The Circle-CI build should not be active, but if this is not true for some reason, do a fast finish.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -2,7 +2,7 @@
 {% set name = "openmc" %}
 {% set version = "0.13.0" %}
 {% set sha256 = "d8ce9c49b398c3e7d99f24d73f8252c77ec764d9230a25e23798c4c4f3a4fb04" %}
-{% set build = 2 %}
+{% set build = 3 %}
 
 # ensure dagmc is defined (needed for conda-smithy recipe-lint)
 {% set dagmc = dagmc or 'nodagmc' %}
@@ -98,16 +98,21 @@ requirements:
     - setuptools
     - {{ mpi }}  # [mpi != 'nompi']
     - openssh  # [mpi == 'openmpi']
+    - ipython
 
 test:
   commands:
     - test -f "${PREFIX}/bin/openmc"
     - openmc --version
+    - pip check
   imports:
     - openmc
     - openmc.data
     - openmc.deplete
     - openmc.lib
+  requires:
+    - pip
+  
 
 about:
   home: https://openmc.org


### PR DESCRIPTION
Noticed in a downstream staged-recipes, which depends on this and runs pip-check:
https://github.com/conda-forge/staged-recipes/pull/18849/files/06d21e85c44a974aca70b85becccf77048f7e69e#r884138802

This comes from the install_requires in openmc's setup.py:
https://github.com/openmc-dev/openmc/blob/0f7ae4b075628263374480d6f0459e1cb6f3f15b/setup.py#L68-L69

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
