### PR TITLE
Add libpng dependency

### DIFF
--- a/.ci_support/linux_64_dagmcdagmcmpimpichnumpy1.20python3.8.____cpython.yaml
+++ b/.ci_support/linux_64_dagmcdagmcmpimpichnumpy1.20python3.8.____cpython.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '10'
+- '11'
 cdt_name:
 - cos6
 channel_sources:
@@ -11,13 +11,15 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '10'
+- '11'
 dagmc:
 - dagmc
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 hdf5:
 - 1.12.2
+libpng:
+- '1.6'
 mpi:
 - mpich
 mpich:

--- a/.ci_support/linux_64_dagmcdagmcmpimpichnumpy1.20python3.9.____cpython.yaml
+++ b/.ci_support/linux_64_dagmcdagmcmpimpichnumpy1.20python3.9.____cpython.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '10'
+- '11'
 cdt_name:
 - cos6
 channel_sources:
@@ -11,13 +11,15 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '10'
+- '11'
 dagmc:
 - dagmc
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 hdf5:
 - 1.12.2
+libpng:
+- '1.6'
 mpi:
 - mpich
 mpich:

--- a/.ci_support/linux_64_dagmcdagmcmpimpichnumpy1.21python3.10.____cpython.yaml
+++ b/.ci_support/linux_64_dagmcdagmcmpimpichnumpy1.21python3.10.____cpython.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '10'
+- '11'
 cdt_name:
 - cos6
 channel_sources:
@@ -11,13 +11,15 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '10'
+- '11'
 dagmc:
 - dagmc
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 hdf5:
 - 1.12.2
+libpng:
+- '1.6'
 mpi:
 - mpich
 mpich:

--- a/.ci_support/linux_64_dagmcdagmcmpimpichnumpy1.23python3.11.____cpython.yaml
+++ b/.ci_support/linux_64_dagmcdagmcmpimpichnumpy1.23python3.11.____cpython.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '10'
+- '11'
 cdt_name:
 - cos6
 channel_sources:
@@ -11,13 +11,15 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '10'
+- '11'
 dagmc:
 - dagmc
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 hdf5:
 - 1.12.2
+libpng:
+- '1.6'
 mpi:
 - mpich
 mpich:

--- a/.ci_support/linux_64_dagmcdagmcmpinompinumpy1.20python3.8.____cpython.yaml
+++ b/.ci_support/linux_64_dagmcdagmcmpinompinumpy1.20python3.8.____cpython.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '10'
+- '11'
 cdt_name:
 - cos6
 channel_sources:
@@ -11,13 +11,15 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '10'
+- '11'
 dagmc:
 - dagmc
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 hdf5:
 - 1.12.2
+libpng:
+- '1.6'
 mpi:
 - nompi
 mpich:

--- a/.ci_support/linux_64_dagmcdagmcmpinompinumpy1.20python3.9.____cpython.yaml
+++ b/.ci_support/linux_64_dagmcdagmcmpinompinumpy1.20python3.9.____cpython.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '10'
+- '11'
 cdt_name:
 - cos6
 channel_sources:
@@ -11,13 +11,15 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '10'
+- '11'
 dagmc:
 - dagmc
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 hdf5:
 - 1.12.2
+libpng:
+- '1.6'
 mpi:
 - nompi
 mpich:

--- a/.ci_support/linux_64_dagmcdagmcmpinompinumpy1.21python3.10.____cpython.yaml
+++ b/.ci_support/linux_64_dagmcdagmcmpinompinumpy1.21python3.10.____cpython.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '10'
+- '11'
 cdt_name:
 - cos6
 channel_sources:
@@ -11,13 +11,15 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '10'
+- '11'
 dagmc:
 - dagmc
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 hdf5:
 - 1.12.2
+libpng:
+- '1.6'
 mpi:
 - nompi
 mpich:

--- a/.ci_support/linux_64_dagmcdagmcmpinompinumpy1.23python3.11.____cpython.yaml
+++ b/.ci_support/linux_64_dagmcdagmcmpinompinumpy1.23python3.11.____cpython.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '10'
+- '11'
 cdt_name:
 - cos6
 channel_sources:
@@ -11,13 +11,15 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '10'
+- '11'
 dagmc:
 - dagmc
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 hdf5:
 - 1.12.2
+libpng:
+- '1.6'
 mpi:
 - nompi
 mpich:

--- a/.ci_support/linux_64_dagmcdagmcmpiopenmpinumpy1.20python3.8.____cpython.yaml
+++ b/.ci_support/linux_64_dagmcdagmcmpiopenmpinumpy1.20python3.8.____cpython.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '10'
+- '11'
 cdt_name:
 - cos6
 channel_sources:
@@ -11,13 +11,15 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '10'
+- '11'
 dagmc:
 - dagmc
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 hdf5:
 - 1.12.2
+libpng:
+- '1.6'
 mpi:
 - openmpi
 mpich:

--- a/.ci_support/linux_64_dagmcdagmcmpiopenmpinumpy1.20python3.9.____cpython.yaml
+++ b/.ci_support/linux_64_dagmcdagmcmpiopenmpinumpy1.20python3.9.____cpython.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '10'
+- '11'
 cdt_name:
 - cos6
 channel_sources:
@@ -11,13 +11,15 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '10'
+- '11'
 dagmc:
 - dagmc
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 hdf5:
 - 1.12.2
+libpng:
+- '1.6'
 mpi:
 - openmpi
 mpich:

--- a/.ci_support/linux_64_dagmcdagmcmpiopenmpinumpy1.21python3.10.____cpython.yaml
+++ b/.ci_support/linux_64_dagmcdagmcmpiopenmpinumpy1.21python3.10.____cpython.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '10'
+- '11'
 cdt_name:
 - cos6
 channel_sources:
@@ -11,13 +11,15 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '10'
+- '11'
 dagmc:
 - dagmc
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 hdf5:
 - 1.12.2
+libpng:
+- '1.6'
 mpi:
 - openmpi
 mpich:

--- a/.ci_support/linux_64_dagmcdagmcmpiopenmpinumpy1.23python3.11.____cpython.yaml
+++ b/.ci_support/linux_64_dagmcdagmcmpiopenmpinumpy1.23python3.11.____cpython.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '10'
+- '11'
 cdt_name:
 - cos6
 channel_sources:
@@ -11,13 +11,15 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '10'
+- '11'
 dagmc:
 - dagmc
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 hdf5:
 - 1.12.2
+libpng:
+- '1.6'
 mpi:
 - openmpi
 mpich:

--- a/.ci_support/linux_64_dagmcnodagmcmpimpichnumpy1.20python3.8.____cpython.yaml
+++ b/.ci_support/linux_64_dagmcnodagmcmpimpichnumpy1.20python3.8.____cpython.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '10'
+- '11'
 cdt_name:
 - cos6
 channel_sources:
@@ -11,13 +11,15 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '10'
+- '11'
 dagmc:
 - nodagmc
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 hdf5:
 - 1.12.2
+libpng:
+- '1.6'
 mpi:
 - mpich
 mpich:

--- a/.ci_support/linux_64_dagmcnodagmcmpimpichnumpy1.20python3.9.____cpython.yaml
+++ b/.ci_support/linux_64_dagmcnodagmcmpimpichnumpy1.20python3.9.____cpython.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '10'
+- '11'
 cdt_name:
 - cos6
 channel_sources:
@@ -11,13 +11,15 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '10'
+- '11'
 dagmc:
 - nodagmc
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 hdf5:
 - 1.12.2
+libpng:
+- '1.6'
 mpi:
 - mpich
 mpich:

--- a/.ci_support/linux_64_dagmcnodagmcmpimpichnumpy1.21python3.10.____cpython.yaml
+++ b/.ci_support/linux_64_dagmcnodagmcmpimpichnumpy1.21python3.10.____cpython.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '10'
+- '11'
 cdt_name:
 - cos6
 channel_sources:
@@ -11,13 +11,15 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '10'
+- '11'
 dagmc:
 - nodagmc
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 hdf5:
 - 1.12.2
+libpng:
+- '1.6'
 mpi:
 - mpich
 mpich:

--- a/.ci_support/linux_64_dagmcnodagmcmpimpichnumpy1.23python3.11.____cpython.yaml
+++ b/.ci_support/linux_64_dagmcnodagmcmpimpichnumpy1.23python3.11.____cpython.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '10'
+- '11'
 cdt_name:
 - cos6
 channel_sources:
@@ -11,13 +11,15 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '10'
+- '11'
 dagmc:
 - nodagmc
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 hdf5:
 - 1.12.2
+libpng:
+- '1.6'
 mpi:
 - mpich
 mpich:

--- a/.ci_support/linux_64_dagmcnodagmcmpinompinumpy1.20python3.8.____cpython.yaml
+++ b/.ci_support/linux_64_dagmcnodagmcmpinompinumpy1.20python3.8.____cpython.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '10'
+- '11'
 cdt_name:
 - cos6
 channel_sources:
@@ -11,13 +11,15 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '10'
+- '11'
 dagmc:
 - nodagmc
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 hdf5:
 - 1.12.2
+libpng:
+- '1.6'
 mpi:
 - nompi
 mpich:

--- a/.ci_support/linux_64_dagmcnodagmcmpinompinumpy1.20python3.9.____cpython.yaml
+++ b/.ci_support/linux_64_dagmcnodagmcmpinompinumpy1.20python3.9.____cpython.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '10'
+- '11'
 cdt_name:
 - cos6
 channel_sources:
@@ -11,13 +11,15 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '10'
+- '11'
 dagmc:
 - nodagmc
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 hdf5:
 - 1.12.2
+libpng:
+- '1.6'
 mpi:
 - nompi
 mpich:

--- a/.ci_support/linux_64_dagmcnodagmcmpinompinumpy1.21python3.10.____cpython.yaml
+++ b/.ci_support/linux_64_dagmcnodagmcmpinompinumpy1.21python3.10.____cpython.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '10'
+- '11'
 cdt_name:
 - cos6
 channel_sources:
@@ -11,13 +11,15 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '10'
+- '11'
 dagmc:
 - nodagmc
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 hdf5:
 - 1.12.2
+libpng:
+- '1.6'
 mpi:
 - nompi
 mpich:

--- a/.ci_support/linux_64_dagmcnodagmcmpinompinumpy1.23python3.11.____cpython.yaml
+++ b/.ci_support/linux_64_dagmcnodagmcmpinompinumpy1.23python3.11.____cpython.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '10'
+- '11'
 cdt_name:
 - cos6
 channel_sources:
@@ -11,13 +11,15 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '10'
+- '11'
 dagmc:
 - nodagmc
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 hdf5:
 - 1.12.2
+libpng:
+- '1.6'
 mpi:
 - nompi
 mpich:

--- a/.ci_support/linux_64_dagmcnodagmcmpiopenmpinumpy1.20python3.8.____cpython.yaml
+++ b/.ci_support/linux_64_dagmcnodagmcmpiopenmpinumpy1.20python3.8.____cpython.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '10'
+- '11'
 cdt_name:
 - cos6
 channel_sources:
@@ -11,13 +11,15 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '10'
+- '11'
 dagmc:
 - nodagmc
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 hdf5:
 - 1.12.2
+libpng:
+- '1.6'
 mpi:
 - openmpi
 mpich:

--- a/.ci_support/linux_64_dagmcnodagmcmpiopenmpinumpy1.20python3.9.____cpython.yaml
+++ b/.ci_support/linux_64_dagmcnodagmcmpiopenmpinumpy1.20python3.9.____cpython.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '10'
+- '11'
 cdt_name:
 - cos6
 channel_sources:
@@ -11,13 +11,15 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '10'
+- '11'
 dagmc:
 - nodagmc
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 hdf5:
 - 1.12.2
+libpng:
+- '1.6'
 mpi:
 - openmpi
 mpich:

--- a/.ci_support/linux_64_dagmcnodagmcmpiopenmpinumpy1.21python3.10.____cpython.yaml
+++ b/.ci_support/linux_64_dagmcnodagmcmpiopenmpinumpy1.21python3.10.____cpython.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '10'
+- '11'
 cdt_name:
 - cos6
 channel_sources:
@@ -11,13 +11,15 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '10'
+- '11'
 dagmc:
 - nodagmc
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 hdf5:
 - 1.12.2
+libpng:
+- '1.6'
 mpi:
 - openmpi
 mpich:

--- a/.ci_support/linux_64_dagmcnodagmcmpiopenmpinumpy1.23python3.11.____cpython.yaml
+++ b/.ci_support/linux_64_dagmcnodagmcmpiopenmpinumpy1.23python3.11.____cpython.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '10'
+- '11'
 cdt_name:
 - cos6
 channel_sources:
@@ -11,13 +11,15 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '10'
+- '11'
 dagmc:
 - nodagmc
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 hdf5:
 - 1.12.2
+libpng:
+- '1.6'
 mpi:
 - openmpi
 mpich:

--- a/.ci_support/migrations/hdf51122.yaml
+++ b/.ci_support/migrations/hdf51122.yaml
@@ -1,7 +1,0 @@
-__migrator:
-  build_number: 1
-  kind: version
-  migration_number: 1
-hdf5:
-- 1.12.2
-migrator_ts: 1658944374.2290778

--- a/.ci_support/osx_64_dagmcdagmcmpimpichnumpy1.20python3.8.____cpython.yaml
+++ b/.ci_support/osx_64_dagmcdagmcmpimpichnumpy1.20python3.8.____cpython.yaml
@@ -16,6 +16,8 @@ dagmc:
 - dagmc
 hdf5:
 - 1.12.2
+libpng:
+- '1.6'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 mpi:

--- a/.ci_support/osx_64_dagmcdagmcmpimpichnumpy1.20python3.9.____cpython.yaml
+++ b/.ci_support/osx_64_dagmcdagmcmpimpichnumpy1.20python3.9.____cpython.yaml
@@ -16,6 +16,8 @@ dagmc:
 - dagmc
 hdf5:
 - 1.12.2
+libpng:
+- '1.6'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 mpi:

--- a/.ci_support/osx_64_dagmcdagmcmpimpichnumpy1.21python3.10.____cpython.yaml
+++ b/.ci_support/osx_64_dagmcdagmcmpimpichnumpy1.21python3.10.____cpython.yaml
@@ -16,6 +16,8 @@ dagmc:
 - dagmc
 hdf5:
 - 1.12.2
+libpng:
+- '1.6'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 mpi:

--- a/.ci_support/osx_64_dagmcdagmcmpimpichnumpy1.23python3.11.____cpython.yaml
+++ b/.ci_support/osx_64_dagmcdagmcmpimpichnumpy1.23python3.11.____cpython.yaml
@@ -16,6 +16,8 @@ dagmc:
 - dagmc
 hdf5:
 - 1.12.2
+libpng:
+- '1.6'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 mpi:

--- a/.ci_support/osx_64_dagmcdagmcmpinompinumpy1.20python3.8.____cpython.yaml
+++ b/.ci_support/osx_64_dagmcdagmcmpinompinumpy1.20python3.8.____cpython.yaml
@@ -16,6 +16,8 @@ dagmc:
 - dagmc
 hdf5:
 - 1.12.2
+libpng:
+- '1.6'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 mpi:

--- a/.ci_support/osx_64_dagmcdagmcmpinompinumpy1.20python3.9.____cpython.yaml
+++ b/.ci_support/osx_64_dagmcdagmcmpinompinumpy1.20python3.9.____cpython.yaml
@@ -16,6 +16,8 @@ dagmc:
 - dagmc
 hdf5:
 - 1.12.2
+libpng:
+- '1.6'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 mpi:

--- a/.ci_support/osx_64_dagmcdagmcmpinompinumpy1.21python3.10.____cpython.yaml
+++ b/.ci_support/osx_64_dagmcdagmcmpinompinumpy1.21python3.10.____cpython.yaml
@@ -16,6 +16,8 @@ dagmc:
 - dagmc
 hdf5:
 - 1.12.2
+libpng:
+- '1.6'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 mpi:

--- a/.ci_support/osx_64_dagmcdagmcmpinompinumpy1.23python3.11.____cpython.yaml
+++ b/.ci_support/osx_64_dagmcdagmcmpinompinumpy1.23python3.11.____cpython.yaml
@@ -16,6 +16,8 @@ dagmc:
 - dagmc
 hdf5:
 - 1.12.2
+libpng:
+- '1.6'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 mpi:

--- a/.ci_support/osx_64_dagmcdagmcmpiopenmpinumpy1.20python3.8.____cpython.yaml
+++ b/.ci_support/osx_64_dagmcdagmcmpiopenmpinumpy1.20python3.8.____cpython.yaml
@@ -16,6 +16,8 @@ dagmc:
 - dagmc
 hdf5:
 - 1.12.2
+libpng:
+- '1.6'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 mpi:

--- a/.ci_support/osx_64_dagmcdagmcmpiopenmpinumpy1.20python3.9.____cpython.yaml
+++ b/.ci_support/osx_64_dagmcdagmcmpiopenmpinumpy1.20python3.9.____cpython.yaml
@@ -16,6 +16,8 @@ dagmc:
 - dagmc
 hdf5:
 - 1.12.2
+libpng:
+- '1.6'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 mpi:

--- a/.ci_support/osx_64_dagmcdagmcmpiopenmpinumpy1.21python3.10.____cpython.yaml
+++ b/.ci_support/osx_64_dagmcdagmcmpiopenmpinumpy1.21python3.10.____cpython.yaml
@@ -16,6 +16,8 @@ dagmc:
 - dagmc
 hdf5:
 - 1.12.2
+libpng:
+- '1.6'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 mpi:

--- a/.ci_support/osx_64_dagmcdagmcmpiopenmpinumpy1.23python3.11.____cpython.yaml
+++ b/.ci_support/osx_64_dagmcdagmcmpiopenmpinumpy1.23python3.11.____cpython.yaml
@@ -16,6 +16,8 @@ dagmc:
 - dagmc
 hdf5:
 - 1.12.2
+libpng:
+- '1.6'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 mpi:

--- a/.ci_support/osx_64_dagmcnodagmcmpimpichnumpy1.20python3.8.____cpython.yaml
+++ b/.ci_support/osx_64_dagmcnodagmcmpimpichnumpy1.20python3.8.____cpython.yaml
@@ -16,6 +16,8 @@ dagmc:
 - nodagmc
 hdf5:
 - 1.12.2
+libpng:
+- '1.6'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 mpi:

--- a/.ci_support/osx_64_dagmcnodagmcmpimpichnumpy1.20python3.9.____cpython.yaml
+++ b/.ci_support/osx_64_dagmcnodagmcmpimpichnumpy1.20python3.9.____cpython.yaml
@@ -16,6 +16,8 @@ dagmc:
 - nodagmc
 hdf5:
 - 1.12.2
+libpng:
+- '1.6'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 mpi:

--- a/.ci_support/osx_64_dagmcnodagmcmpimpichnumpy1.21python3.10.____cpython.yaml
+++ b/.ci_support/osx_64_dagmcnodagmcmpimpichnumpy1.21python3.10.____cpython.yaml
@@ -16,6 +16,8 @@ dagmc:
 - nodagmc
 hdf5:
 - 1.12.2
+libpng:
+- '1.6'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 mpi:

--- a/.ci_support/osx_64_dagmcnodagmcmpimpichnumpy1.23python3.11.____cpython.yaml
+++ b/.ci_support/osx_64_dagmcnodagmcmpimpichnumpy1.23python3.11.____cpython.yaml
@@ -16,6 +16,8 @@ dagmc:
 - nodagmc
 hdf5:
 - 1.12.2
+libpng:
+- '1.6'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 mpi:

--- a/.ci_support/osx_64_dagmcnodagmcmpinompinumpy1.20python3.8.____cpython.yaml
+++ b/.ci_support/osx_64_dagmcnodagmcmpinompinumpy1.20python3.8.____cpython.yaml
@@ -16,6 +16,8 @@ dagmc:
 - nodagmc
 hdf5:
 - 1.12.2
+libpng:
+- '1.6'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 mpi:

--- a/.ci_support/osx_64_dagmcnodagmcmpinompinumpy1.20python3.9.____cpython.yaml
+++ b/.ci_support/osx_64_dagmcnodagmcmpinompinumpy1.20python3.9.____cpython.yaml
@@ -16,6 +16,8 @@ dagmc:
 - nodagmc
 hdf5:
 - 1.12.2
+libpng:
+- '1.6'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 mpi:

--- a/.ci_support/osx_64_dagmcnodagmcmpinompinumpy1.21python3.10.____cpython.yaml
+++ b/.ci_support/osx_64_dagmcnodagmcmpinompinumpy1.21python3.10.____cpython.yaml
@@ -16,6 +16,8 @@ dagmc:
 - nodagmc
 hdf5:
 - 1.12.2
+libpng:
+- '1.6'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 mpi:

--- a/.ci_support/osx_64_dagmcnodagmcmpinompinumpy1.23python3.11.____cpython.yaml
+++ b/.ci_support/osx_64_dagmcnodagmcmpinompinumpy1.23python3.11.____cpython.yaml
@@ -16,6 +16,8 @@ dagmc:
 - nodagmc
 hdf5:
 - 1.12.2
+libpng:
+- '1.6'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 mpi:

--- a/.ci_support/osx_64_dagmcnodagmcmpiopenmpinumpy1.20python3.8.____cpython.yaml
+++ b/.ci_support/osx_64_dagmcnodagmcmpiopenmpinumpy1.20python3.8.____cpython.yaml
@@ -16,6 +16,8 @@ dagmc:
 - nodagmc
 hdf5:
 - 1.12.2
+libpng:
+- '1.6'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 mpi:

--- a/.ci_support/osx_64_dagmcnodagmcmpiopenmpinumpy1.20python3.9.____cpython.yaml
+++ b/.ci_support/osx_64_dagmcnodagmcmpiopenmpinumpy1.20python3.9.____cpython.yaml
@@ -16,6 +16,8 @@ dagmc:
 - nodagmc
 hdf5:
 - 1.12.2
+libpng:
+- '1.6'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 mpi:

--- a/.ci_support/osx_64_dagmcnodagmcmpiopenmpinumpy1.21python3.10.____cpython.yaml
+++ b/.ci_support/osx_64_dagmcnodagmcmpiopenmpinumpy1.21python3.10.____cpython.yaml
@@ -16,6 +16,8 @@ dagmc:
 - nodagmc
 hdf5:
 - 1.12.2
+libpng:
+- '1.6'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 mpi:

--- a/.ci_support/osx_64_dagmcnodagmcmpiopenmpinumpy1.23python3.11.____cpython.yaml
+++ b/.ci_support/osx_64_dagmcnodagmcmpiopenmpinumpy1.23python3.11.____cpython.yaml
@@ -16,6 +16,8 @@ dagmc:
 - nodagmc
 hdf5:
 - 1.12.2
+libpng:
+- '1.6'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 mpi:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -2,7 +2,7 @@
 {% set name = "openmc" %}
 {% set version = "0.13.2" %}
 {% set sha256 = "dcffc95874c893085feb85f3dbc766f260818b0fcc9f16627759eef47c4439be" %}
-{% set build = 1 %}
+{% set build = 2 %}
 
 # ensure dagmc is defined (needed for conda-smithy recipe-lint)
 {% set dagmc = dagmc or 'nodagmc' %}
@@ -74,6 +74,7 @@ requirements:
     - dagmc 3.2.2 {{ mpi_prefix }}_*  # [dagmc == 'dagmc']
     - hdf5
     - hdf5 * {{ mpi_prefix }}_*
+    - libpng
     - git
     - setuptools
     - pip
@@ -87,6 +88,7 @@ requirements:
     - dagmc 3.2.2 {{ mpi_prefix }}_*  # [dagmc == 'dagmc']
     - hdf5
     - hdf5 * {{ mpi_prefix }}_*
+    - libpng
     - python
     - {{ pin_compatible('numpy') }}
     - h5py * {{ mpi_prefix }}_*


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

A number of users have [noted problems with libpng](https://openmc.discourse.group/t/runtimeerror-when-plotting-in-pincell-tutorials-universe-plot-and-openmc-plot-geometry/2605) when using the conda-forge package. It looks like the issue is that the openmc package doesn't specify a dependency on libpng, so it ends up picking up a default system version of libpng (that is different than what is used at runtime). Hopefully specifying libpng as a host/run dependency should resolve this.